### PR TITLE
feat: Menu.jsx 구현

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -4,6 +4,7 @@ import Header from "./components/Header.jsx";
 import "./index.css"
 import Main from "./components/Main.jsx";
 import Notice from "./components/Notice.jsx";
+import Menu from "./components/Menu.jsx";
 
 function App() {
 
@@ -13,6 +14,7 @@ function App() {
         <Header/>
         <Main/>
         <Notice/>
+        <Menu/>
       </Mobile>
       <Pc><h2 className="text-2xl font-bold">PC는 아직 작업중입니다.</h2></Pc>
     </>

--- a/front-end/src/components/Menu.jsx
+++ b/front-end/src/components/Menu.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import {SlArrowLeft, SlArrowRight} from "react-icons/sl";
+
+export default function Menu() {
+  const arrowStyle = {
+    fontSize:"24px",
+    color: "#7b9acc",
+  };
+  return (
+    <div className="flex justify-center">
+      <div className="w-11/12 h-32 border-2 border-black rounded-lg mt-10 flex flex-col">
+        <header className="w-full h-10 rounded-t border-white bg-blue-300 flex items-center justify-around ">
+          <span className="text-white ">오늘의 식단</span>
+          <span className="absolute right-8 text-white text-lg">+</span>
+        </header>
+        <div className="flex justify-between items-center">
+          <button className=""><SlArrowLeft style={arrowStyle}/></button>
+          <figure className="text-center">
+            <p>09.05 점심</p>
+            <span>쌀밥, 남부식콩나물국밥, 눈꽃토마토소스미트볼,구운어묶볶음,부추무침,깍두기</span>
+          </figure>
+          <button className=""><SlArrowRight style={arrowStyle}/></button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요
- Menu.jsx를 구현했습니다.
![image](https://github.com/Smart-Dormitory/smart-dormitory-frontend/assets/67476544/f321dfbc-9651-429c-865a-dd733626720b)
## 개선
- 디자인 요구사항대로 화살표 아이콘을 두껍게 해야합니다.
- flex로 묶어둔 레이아웃에서 figure 의 컨텐츠가 늘어나면 양쪽 화살표 이모티콘을 담고있는 button 의 height도 같이 늘어나게 됩니다. aside 를 사용해 구획하거나 Menu.jsx의 콘텐츠는 그날의 식단만 보여주기 때문에 font-size를 줄여 넘치지 않게 하는방법을 고민해야합니다.